### PR TITLE
Fix: Order service Queue Connection

### DIFF
--- a/.github/workflows/cd-deploy-k8s-to-aws-eks-tf.yaml
+++ b/.github/workflows/cd-deploy-k8s-to-aws-eks-tf.yaml
@@ -26,6 +26,17 @@ jobs:
           aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Encode secrets to base64
+        id: base64_encode
+        run: |
+          echo "::set-output name=db_order_dns::$(echo -n ${{ secrets.DB_ORDER_DSN }} | base64 -w 0)"
+          echo "::set-output name=db_order_user::$(echo -n ${{ secrets.DB_ORDER_USER }} | base64 -w 0)"
+          echo "::set-output name=db_order_password::$(echo -n ${{ secrets.DB_ORDER_PASSWORD }} | base64 -w 0)"
+          echo "::set-output name=aws_access_key_id::$(echo -n ${{ secrets.AWS_ACCESS_KEY_ID }} | base64 -w 0)"
+          echo "::set-output name=aws_secret_access_key::$(echo -n ${{ secrets.AWS_SECRET_ACCESS_KEY }} | base64 -w 0)"
+          echo "::set-output name=aws_session_token::$(echo -n ${{ secrets.AWS_SESSION_TOKEN }} | base64 -w 0)"
+        shell: bash
+
       - name: Update Kube Config
         run: |
           aws eks update-kubeconfig \
@@ -37,10 +48,15 @@ jobs:
           envsubst < config/configmap.yaml > config/configmap-f.yaml
           envsubst < config/secrets.yaml > config/secrets-f.yaml
         env:
-          DB_ORDER_DSN: ${{ secrets.DB_ORDER_DSN }}
+          DB_ORDER_DSN: ${{ steps.base64_encode.outputs.db_order_dns }}
           DB_ORDER_NAME: ${{ secrets.DB_ORDER_NAME }}
-          DB_ORDER_USER: ${{ secrets.DB_ORDER_USER }}
-          DB_ORDER_PASSWORD: ${{ secrets.DB_ORDER_PASSWORD }}
+          DB_ORDER_USER: ${{ steps.base64_encode.outputs.db_order_user }}
+          DB_ORDER_PASSWORD: ${{ steps.base64_encode.outputs.db_order_password }}
+          AWS_ACCESS_KEY_ID: ${{ steps.base64_encode.outputs.aws_access_key_id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.base64_encode.outputs.aws_secret_access_key }}
+          AWS_SESSION_TOKEN: ${{ steps.base64_encode.outputs.aws_session_token }}
+          AWS_REGION: ${{ env.AWS_REGION }}
+          AWS_SQS_ORDER_QUEUE_NAME: ${{ secrets.AWS_SQS_ORDER_QUEUE_NAME }}
 
       - name: Kube Apply
         run: |

--- a/.github/workflows/cd-deploy-k8s-to-aws-eks.yaml
+++ b/.github/workflows/cd-deploy-k8s-to-aws-eks.yaml
@@ -1,4 +1,4 @@
-name: cd/deploy-k8s-to-aws-eks-tf
+name: cd/deploy-k8s-to-aws-eks
 
 on:
   workflow_dispatch:
@@ -12,7 +12,7 @@ env:
 
 jobs:
   deploy-production:
-    name: CD - Deploy K8s to AWS EKS with Terraform
+    name: CD - Deploy K8s to AWS EKS
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo

--- a/config/configmap.yaml
+++ b/config/configmap.yaml
@@ -5,7 +5,9 @@ metadata:
   namespace: tech-challenge-ns
 data:
   jwt_secret: "my-jwt-secret"
-  db_order_name: "${DB_ORDER_NAME}" # "fastfood_10soat_g22_tc3"
+  db_order_name: "${DB_ORDER_NAME}" # "fastfood_10soat_g19_tc4_order"
+  aws_sqs_order_queue_name: "${AWS_SQS_ORDER_QUEUE_NAME}" # "order-status-updated"
+  aws_region: "${AWS_REGION}" # "us-east-1"
   environment: "tech-challenge"
   fake_mercado_pago_url: "http://mock-server.tech-challenge-ns.svc.cluster.local:80/mercadopago/instore/orders/qr"
   fake_mercado_pago_notification_url: "http://tech-challenge-api.tech-challenge-ns.svc.cluster.local:80/api/v1/payments/callback"

--- a/config/secrets.yaml
+++ b/config/secrets.yaml
@@ -8,5 +8,8 @@ data: # do not use these values in production
   db_order_user: "${DB_ORDER_USER}" # base64 encoded value of "postgres"
   db_order_password: "${DB_ORDER_PASSWORD}" # base64 encoded value of "postgres"
   db_order_dsn: "${DB_ORDER_DSN}" # base64 encoded value of "postgres://..."
+  aws_access_key_id: "${AWS_ACCESS_KEY_ID}" # base64 encoded value of your AWS access key ID
+  aws_secret_access_key: "${AWS_SECRET_ACCESS_KEY}" # base64 encoded value of your AWS secret access key
+  aws_session_token: "${AWS_SESSION_TOKEN}" # base64 encoded value
 
 # In production, you should use a secret management tool like HashiCorp Vault or AWS Secrets Manager

--- a/order-service/worker/deployment.yaml
+++ b/order-service/worker/deployment.yaml
@@ -26,6 +26,31 @@ spec:
                 secretKeyRef:
                   name: tech-challenge-secrets
                   key: db_order_dsn
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: tech-challenge-secrets
+                  key: aws_access_key_id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: tech-challenge-secrets
+                  key: aws_secret_access_key
+            - name: AWS_SESSION_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: tech-challenge-secrets
+                  key: aws_session_token
+            - name: AWS_REGION
+              valueFrom:
+                configMapKeyRef:
+                  name: tech-challenge-config
+                  key: aws_region
+            - name: AWS_SQS_ORDER_QUEUE_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: tech-challenge-config
+                  key: aws_sqs_order_queue_name
             - name: JWT_SECRET
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
- Includes AWS credentials so the Order Service worker can connect to the queue.
- Adjusted the GH workflow to automatically generate base64 envs. Now there's no need to register base64 envs in GH secrets.