### PR TITLE
Refactor: Update envs for order service to use correct SQS URL

### DIFF
--- a/.github/workflows/cd-deploy-k8s-to-aws-eks.yaml
+++ b/.github/workflows/cd-deploy-k8s-to-aws-eks.yaml
@@ -59,7 +59,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ steps.base64_encode.outputs.aws_secret_access_key }}
           AWS_SESSION_TOKEN: ${{ steps.base64_encode.outputs.aws_session_token }}
           AWS_REGION: ${{ env.AWS_REGION }}
-          AWS_SQS_ORDER_QUEUE_NAME: ${{ secrets.AWS_SQS_ORDER_QUEUE_NAME }}
+          AWS_SQS_ORDER_STATUS_UPDATED_URL: ${{ secrets.AWS_SQS_ORDER_STATUS_UPDATED_URL }}
           DB_KITCHEN_DSN: ${{ secrets.DB_KITCHEN_DSN }}
           AWS_SQS_PAYMENT_APPROVED_QUEUE_URL: ${{ secrets.AWS_SQS_PAYMENT_APPROVED_QUEUE_URL }}
           AWS_SQS_ORDER_STATUS_QUEUE_URL: ${{ secrets.AWS_SQS_ORDER_STATUS_QUEUE_URL }}

--- a/configs/order-service-config.yaml
+++ b/configs/order-service-config.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   jwt_secret: "my-jwt-secret"
   db_order_name: "${DB_ORDER_NAME}" # "fastfood_10soat_g19_tc4_order"
-  aws_sqs_order_queue_name: "${AWS_SQS_ORDER_QUEUE_NAME}" # "order-status-updated"
+  aws_sqs_order_status_updated_url: "${AWS_SQS_ORDER_STATUS_UPDATED_URL}" # "order-status-updated"
   aws_region: "${AWS_REGION}" # "us-east-1"
   environment: "tech-challenge"
   fake_mercado_pago_url: "http://mock-server.tech-challenge-ns.svc.cluster.local:80/mercadopago/instore/orders/qr"

--- a/services/order-service/worker/deployment.yaml
+++ b/services/order-service/worker/deployment.yaml
@@ -46,11 +46,11 @@ spec:
                 configMapKeyRef:
                   name: tech-challenge-config
                   key: aws_region
-            - name: AWS_SQS_ORDER_QUEUE_NAME
+            - name: AWS_SQS_ORDER_STATUS_UPDATED_URL
               valueFrom:
                 configMapKeyRef:
                   name: tech-challenge-config
-                  key: aws_sqs_order_queue_name
+                  key: aws_sqs_order_status_updated_url
             - name: JWT_SECRET
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
This pull request updates the configuration and deployment files to replace the use of `AWS_SQS_ORDER_QUEUE_NAME` with `AWS_SQS_ORDER_STATUS_UPDATED_URL`. The changes ensure consistency across environment variables and configuration keys.

### Environment variable updates:

* [`.github/workflows/cd-deploy-k8s-to-aws-eks.yaml`](diffhunk://#diff-f051b48c7786186736f9664889827ac6ee90254c0172b878c06e0cd4de55c15aL62-R62): Replaced `AWS_SQS_ORDER_QUEUE_NAME` with `AWS_SQS_ORDER_STATUS_UPDATED_URL` in the workflow environment variables.

### Configuration updates:

* [`configs/order-service-config.yaml`](diffhunk://#diff-e9775abb5532aef24d4663a63ca40c4da39e0bd7bbe6f0ccdbddf1814146eea2L9-R9): Updated the configuration key from `aws_sqs_order_queue_name` to `aws_sqs_order_status_updated_url` to align with the new environment variable.

### Deployment updates:

* [`services/order-service/worker/deployment.yaml`](diffhunk://#diff-195d73b54e1615da72c43e03ace20a6984ebdebd983016f4d61d99a1187cb993L49-R53): Replaced the environment variable and corresponding `configMapKeyRef` key from `AWS_SQS_ORDER_QUEUE_NAME` to `AWS_SQS_ORDER_STATUS_UPDATED_URL` in the worker deployment specification.