### PR TITLE
feat: add labrole service account and update deployments

### DIFF
--- a/.github/workflows/cd-deploy-k8s-to-aws-eks.yaml
+++ b/.github/workflows/cd-deploy-k8s-to-aws-eks.yaml
@@ -79,6 +79,7 @@ jobs:
           kubectl apply --dry-run=client -f services/order-service/api/
           kubectl apply --dry-run=client -f services/order-service/worker/
           kubectl apply --dry-run=client -f services/mockserver/
+          kubectl apply --dry-run=client -f security/
           echo "Validating ingress..."
           kubectl apply --dry-run=client -f ingress/ingress.yaml
         env:
@@ -106,6 +107,7 @@ jobs:
           kubectl apply -f configs/payment-service-config.yaml
           kubectl apply -f configs/secrets.yaml
           kubectl apply -f configs/metrics.yaml
+          kubectl apply -f security/
           kubectl apply -f services/customer-service/
           kubectl apply -f services/payment-service/
           kubectl apply -f services/kitchen-service/api/
@@ -114,3 +116,4 @@ jobs:
           kubectl apply -f services/order-service/worker/
           kubectl apply -f services/mockserver/
           kubectl apply -f ingress/ingress.yaml
+

--- a/security/labrole-service-account.yaml
+++ b/security/labrole-service-account.yaml
@@ -1,0 +1,21 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: labrole
+  namespace: tech-challenge-ns
+  uid: 396de304-94cf-463a-9c0a-fead0cebf227
+  resourceVersion: '31441'
+  creationTimestamp: '2025-07-26T19:58:21Z'
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::829401394278:role/LabRole
+  managedFields:
+    - manager: Mozilla
+      operation: Update
+      apiVersion: v1
+      time: '2025-07-26T19:58:21Z'
+      fieldsType: FieldsV1
+      fieldsV1:
+        f:metadata:
+          f:annotations:
+            .: {}
+            f:eks.amazonaws.com/role-arn: {}

--- a/services/kitchen-service/worker/deployment.yaml
+++ b/services/kitchen-service/worker/deployment.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         app: tc4-kitchen-consumer-worker
     spec:
+      serviceAccountName: labrole
       containers:
         - name: tc4-kitchen-consumer-worker
           image: ghcr.io/fiap-soat-g20/tc4-kitchen-service-consumer-worker:latest

--- a/services/order-service/worker/deployment.yaml
+++ b/services/order-service/worker/deployment.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         app: tech-challenge-order-worker
     spec:
+      serviceAccountName: labrole
       containers:
         - name: tech-challenge-order-worker
           image: ghcr.io/fiap-soat-g20/tc4-order-service-worker-consumer:latest

--- a/services/payment-service/deployment.yaml
+++ b/services/payment-service/deployment.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         app: tc4-payment-service
     spec:
+      serviceAccountName: labrole
       containers:
         - name: tc4-payment-service
           image: ghcr.io/fiap-soat-g20/tc4-payment-service:latest


### PR DESCRIPTION
* add labrole service account configuration in security directory
* update kitchen and order service deployments to use labrole service account
* include security directory in dry-run validation steps of CI workflow